### PR TITLE
[Bugfix] Use hexidecimal escape instead of octal escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.12.2
+
+- [Bugfix] Use hexidecimal escape instead of octal escape [(#5)](https://github.com/michaeljaltamirano/publication-parser/pull/5)
+
 # 0.12.1
 
 - [Bugfix] Fix error terminal output color [(#4)](https://github.com/michaeljaltamirano/publication-parser/pull/4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.12.1
+
+- [Bugfix] Fix error terminal output color [(#4)](https://github.com/michaeljaltamirano/publication-parser/pull/4)
+
 # 0.12.0
 
 - [Parsers] Add Times Literary Supplement Support [(#3)](https://github.com/michaeljaltamirano/publication-parser/pull/3)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,7 +34,7 @@ function getOptions({ headers, issueUrl, }) {
 }
 exports.getOptions = getOptions;
 function throwCookieError() {
-    throw new Error('\0o33[31mYOUR COOKIES HAVE EXPIRED! Please reset them to get the full article content');
+    throw new Error('\033[31mYOUR COOKIES HAVE EXPIRED! Please reset them to get the full article content');
 }
 exports.throwCookieError = throwCookieError;
 function handleError(err) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,7 +34,7 @@ function getOptions({ headers, issueUrl, }) {
 }
 exports.getOptions = getOptions;
 function throwCookieError() {
-    throw new Error('\033[31mYOUR COOKIES HAVE EXPIRED! Please reset them to get the full article content');
+    throw new Error('\x1B[31mYOUR COOKIES HAVE EXPIRED! Please reset them to get the full article content');
 }
 exports.throwCookieError = throwCookieError;
 function handleError(err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publication-parser",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Parses the written content of various publications",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publication-parser",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Parses the written content of various publications",
   "main": "lib/index.js",
   "scripts": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,7 +44,7 @@ export function getOptions({
 
 export function throwCookieError() {
   throw new Error(
-    '\033[31mYOUR COOKIES HAVE EXPIRED! Please reset them to get the full article content',
+    '\x1B[31mYOUR COOKIES HAVE EXPIRED! Please reset them to get the full article content',
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,7 +44,7 @@ export function getOptions({
 
 export function throwCookieError() {
   throw new Error(
-    '\0o33[31mYOUR COOKIES HAVE EXPIRED! Please reset them to get the full article content',
+    '\033[31mYOUR COOKIES HAVE EXPIRED! Please reset them to get the full article content',
   );
 }
 


### PR DESCRIPTION
# 0.12.2

- [Bugfix] Use hexidecimal escape instead of octal escape